### PR TITLE
Bugfix/expression column name typos

### DIFF
--- a/docs/variant_inputs.md
+++ b/docs/variant_inputs.md
@@ -24,17 +24,17 @@ use a tab delimited format. The column names, types and example inputs are shown
 | rpkm                  | float | reads per kilobase of transcript, per million mapped reads                                         |
 | tpm                   | float | transcript per million                                                                             |
 | diseasePercentile     | float | the percentile with respect to the disease expression comparator cohort                            |
-| diseaseKIQR           | float | the kIQR with respect to the disease expression comparator cohort                                  |
+| diseasekIQR           | float | the kIQR with respect to the disease expression comparator cohort                                  |
 | diseaseZScore         | float | the zscore with respect to the disease expression comparator cohort                                |
 | diseaseFoldChange     | float | the fold change with respect to the median of the disease expression comparator cohort             |
 | diseaseQC             | float |                                                                                                    |
 | primarySitePercentile | float | the percentile with respect to the normal primary site expression comparator cohort                |
-| primarySiteKIQR       | float | the kIQR with respect to the normal primary site expression comparator cohort                      |
+| primarySitekIQR       | float | the kIQR with respect to the normal primary site expression comparator cohort                      |
 | primarySiteZScore     | float | the zscore with respect to the normal primary site expression comparator cohort                    |
 | primarySiteFoldChange | float | the fold change with respect to the median of the normal primary site expression comparator cohort |
 | primarySiteQC         | float |                                                                                                    |
 | biopsySitePercentile  | float | the percentile with respect to the normal biopsy site expression comparator cohort                 |
-| biopsySiteKIQR        | float | the kIQR with respect to the normal biopsy site expression comparator cohort                       |
+| biopsySitekIQR        | float | the kIQR with respect to the normal biopsy site expression comparator cohort                       |
 | biopsySiteZScore      | float | the zscore with respect to the normal biopsy site expression comparator cohort                     |
 | biopsySiteFoldChange  | float | the fold change with respect to the median of the normal biopsy site expression comparator cohort  |
 | biopsySiteQC          | float |                                                                                                    |

--- a/ipr/inputs.py
+++ b/ipr/inputs.py
@@ -307,7 +307,7 @@ def preprocess_expression_variants(rows: Iterable[Dict]) -> List[IprGeneVariant]
         or col.endswith('FoldChange')
         or col.endswith('QC')
         or col.endswith('ZScore')
-        or col in ['tmp', 'rpkm']
+        or col in ['tpm', 'rpkm']
     ]
     for col in float_columns:
         if col not in patterns:

--- a/ipr/inputs.py
+++ b/ipr/inputs.py
@@ -69,16 +69,16 @@ EXP_OPTIONAL = [
     'biopsySitePercentile',
     'biopsySiteQC',
     'biopsySiteZScore',
-    'biopsySiteKIQR',
+    'biopsySitekIQR',
     'diseaseFoldChange',
-    'diseaseKIQR',
+    'diseasekIQR',
     'diseasePercentile',
     'diseaseQC',
     'diseaseZScore',
     'expressionState',
     'histogramImage',
     'primarySiteFoldChange',
-    'primarySiteKIQR',
+    'primarySitekIQR',
     'primarySitePercentile',
     'primarySiteQC',
     'primarySiteZScore',
@@ -302,7 +302,7 @@ def preprocess_expression_variants(rows: Iterable[Dict]) -> List[IprGeneVariant]
     float_columns = [
         col
         for col in EXP_REQ + EXP_OPTIONAL
-        if col.endswith('KIQR')
+        if col.endswith('kIQR')
         or col.endswith('Percentile')
         or col.endswith('FoldChange')
         or col.endswith('QC')

--- a/tests/test_data/expression.tab
+++ b/tests/test_data/expression.tab
@@ -1,4 +1,4 @@
-gene	rpkm	expressionState	kbCategory	diseasePercentile	diseaseKIQR	diseaseQC	primarySitePercentile	primarySiteKIQR	biopsySiteFoldChange	biopsySiteKIQR	biopsySitePercentile	biopsySiteQC	biopsySiteZScore	diseaseFoldChange	diseaseZScore	primarySiteFoldChange	primarySiteQC	primarySiteZScore	tpm
+gene	rpkm	expressionState	kbCategory	diseasePercentile	diseasekIQR	diseaseQC	primarySitePercentile	primarySitekIQR	biopsySiteFoldChange	biopsySitekIQR	biopsySitePercentile	biopsySiteQC	biopsySiteZScore	diseaseFoldChange	diseaseZScore	primarySiteFoldChange	primarySiteQC	primarySiteZScore	tpm
 MYH16	0.0	no_category		67.0	0.5	66.92	100.0	inf		-0.48	-1.314	33	0.868	0.168	1.027	0.546	32	-0.736	-2.303
 WNT16	0.39	high_percentile	increased expression	86.0	3.02	44.11	100.0	2.27		1.65	2.085	82	0.167	2.664	2.792	1.008	12	-1.278	-1.897
 KLHL13	3.81	no_category		60.0	0.22	46.39	50.0	-0.98		2.72	0.135	80	-2.817	-1.124	-2.24	1.591	63	-0.042	2.859


### PR DESCRIPTION
Column name fixes to match ipr-api MockReport Data 
```
 "expressionVariants": [
        {
            "biopsySitekIQR": 16.82,
            "diseasekIQR": 4.21,
            "primarySitekIQR": 1.04,
            "tpm": 12.3
        }
    ],
```