### PR TITLE
Feature/gero 161 exclude failed statements

### DIFF
--- a/ipr/constants.py
+++ b/ipr/constants.py
@@ -15,3 +15,6 @@ APPROVED_EVIDENCE_LEVELS = {
 }
 
 DEFAULT_URL = 'https://iprstaging-api.bcgsc.ca/api'
+
+# all possible values for review status are: ['pending', 'not required', 'passed', 'failed', 'initial']
+FAILED_REVIEW_STATUS = 'failed'


### PR DESCRIPTION
Improvements
- Do not include statements marked as failed in the matching