### PR TITLE
Release/gero 196 v2.0.5 bugfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ except Exception:
 
 setup(
     name='ipr',
-    version='2.0.4',
+    version='2.0.5',
     packages=find_packages(),
     install_requires=INSTALL_REQS,
     extras_require={


### PR DESCRIPTION
Release v2.0.5

Bugfix
 - GERO-196 - Remove prognostic events without cancer-type matches