### PR TITLE
Split long/short test workflows for better coverage reporting

### DIFF
--- a/.github/workflows/quick-pytest.yml
+++ b/.github/workflows/quick-pytest.yml
@@ -1,14 +1,10 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: build
+name: quick-tests
 
 on:
-  push:
-    branches:
-      - master
-      - develop
-  pull_request:
+  - push
 
 jobs:
   build:
@@ -37,25 +33,9 @@ jobs:
       run: |
         pip install black
         black --check -S -l 100 ipr tests
-    - name: Full Tests with pytest
+    - name: Short Tests with pytest
       run: pytest --junitxml=junit/test-results-${{ matrix.python-version }}.xml --cov ipr --cov-report term --cov-report xml
       env:
         IPR_USER: ${{ secrets.IPR_TEST_USER }}
         IPR_PASS: ${{ secrets.IPR_TEST_PASSWORD }}
-    - name: Upload pytest test results
-      uses: actions/upload-artifact@master
-      with:
-        name: pytest-results-${{ matrix.python-version }}
-        path: junit/test-results-${{ matrix.python-version }}.xml
-        # Use always() to always run this step to publish test results when there are test failures
-      if: matrix.python-version == 3.8
-    - name: Update code coverage report to CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        env_vars: OS,PYTHON
-        name: codecov-umbrella
-        fail_ci_if_error: true
-      if: matrix.python-version == 3.8
+        EXCLUDE_INTEGRATION_TESTS: 1


### PR DESCRIPTION
I noticed that we were only reporting coverage on pull requests and not the branches themselves which meant the front page badge wasn't getting updated (says ~80 should say ~90). I've split the long and the short tests into different workflows to make this simpler

Note: this is NOT a release, just updates the way coverage is reported