### PR TITLE
fix double slash in upload report URL

### DIFF
--- a/ipr/connection.py
+++ b/ipr/connection.py
@@ -63,7 +63,7 @@ class IprConnection:
         )
 
     def upload_report(self, content: Dict) -> Dict:
-        return self.post('/reports', content)
+        return self.post('reports', content)
 
     def set_analyst_comments(self, report_id: str, data: Dict) -> Dict:
         """


### PR DESCRIPTION
Changes the report upload URL from:
https://iprstaging-api.bcgsc.ca/api//reports

to:
https://iprstaging-api.bcgsc.ca/api/reports