### PR TITLE
Feature/add new kb fields

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.6', '3.8', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/quick-pytest.yml
+++ b/.github/workflows/quick-pytest.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/ipr/inputs.py
+++ b/ipr/inputs.py
@@ -213,7 +213,9 @@ def preprocess_small_mutations(rows: Iterable[Dict]) -> List[IprGeneVariant]:
             if not pandas_falsy(row[field]):
                 return row[field]
 
-        raise ValueError('Variant field cannot be empty. Must include proteinChange or one of the hgvs fields (hgvsProtein, hgvsCds, hgvsGenomic) to build the variant string')
+        raise ValueError(
+            'Variant field cannot be empty. Must include proteinChange or one of the hgvs fields (hgvsProtein, hgvsCds, hgvsGenomic) to build the variant string'
+        )
 
     # 'location' and 'refAlt' are not currently used for matching; still optional and allowed blank
 

--- a/ipr/ipr.py
+++ b/ipr/ipr.py
@@ -2,19 +2,15 @@
 Contains functions specific to formatting reports for IPR that are unlikely to be used
 by other reporting systems
 """
-from typing import Dict, Iterable, List, Set, Tuple
-
 from graphkb import GraphKBConnection
+from graphkb.statement import categorize_relevance
 from graphkb.types import Ontology, Statement
 from graphkb.vocab import get_term_tree
-from graphkb.statement import categorize_relevance
+from typing import Dict, Iterable, List, Set, Tuple
 
+from .constants import APPROVED_EVIDENCE_LEVELS, VARIANT_CLASSES
 from .types import ImageDefinition, IprGene, IprStructuralVariant, IprVariant, KbMatch
 from .util import convert_to_rid_set, find_variant
-from .constants import (
-    VARIANT_CLASSES,
-    APPROVED_EVIDENCE_LEVELS,
-)
 
 
 def display_evidence_levels(statement: Statement) -> str:
@@ -145,6 +141,10 @@ def convert_statements_to_alterations(
                     'reference': pmid,
                     'relevance': statement['relevance']['displayName'],
                     'kbRelevanceId': statement['relevance']['@rid'],
+                    'externalSource': statement['source']['displayName']
+                    if statement['source']
+                    else None,
+                    'externalStatementId': statement.get('sourceId'),
                 }
             )
             rows.append(row)

--- a/ipr/types.py
+++ b/ipr/types.py
@@ -22,6 +22,8 @@ class KbMatch(TypedDict):
     reference: str
     relevance: str
     kbRelevanceId: str
+    externalSource: str
+    externalStatementId: str
 
 
 class IprGeneVariant(TypedDict):

--- a/ipr/util.py
+++ b/ipr/util.py
@@ -1,14 +1,13 @@
 import hashlib
 import json
 import logging
-from typing import Dict, List, Set, Tuple
-
+import pandas as pd
+from graphkb import GraphKBConnection
 from graphkb.types import Record
 from graphkb.vocab import get_term_tree
-from graphkb import GraphKBConnection
+from typing import Dict, List, Set, Tuple
 
 from .types import IprVariant
-
 
 # name the logger after the package to make it simple to disable for packages using this one as a dependency
 # https://stackoverflow.com/questions/11029717/how-do-i-disable-log-messages-from-the-requests-library
@@ -179,3 +178,10 @@ def get_preferred_gene_name(graphkb_conn: GraphKBConnection, record_id: str) -> 
         return genes[0]['displayName']
     # fallback to the input displayName
     return record['displayName']
+
+
+def pandas_falsy(field):
+    """
+    Check if a field is python falsy or pandas null
+    """
+    return bool(pd.isnull(field) or not field)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,34 @@
+import pytest
+
+from ipr.util import create_variant_name, trim_empty_values
+
+
+@pytest.mark.parametrize(
+    'input,output_keys',
+    [[{'key': 0}, ['key']], [{'key': None}, []], [{'key': ''}, []], [{'gene1': None}, ['gene1']]],
+)
+def test_trim_empty_values(input, output_keys):
+    modified_object = trim_empty_values(input)
+    assert sorted(modified_object.keys()) == sorted(output_keys)
+
+
+@pytest.mark.parametrize(
+    'variant,result',
+    [
+        [
+            {'variantType': 'exp', 'gene': 'GENE', 'expressionState': 'increased expression'},
+            'GENE (increased expression)',
+        ],
+        [
+            {'variantType': 'cnv', 'gene': 'GENE', 'cnvState': 'amplification'},
+            'GENE (amplification)',
+        ],
+        [
+            {'variantType': 'other', 'variant': 'anything'},
+            'anything',
+        ],
+    ],
+)
+def test_create_variant_name(variant, result):
+    name = create_variant_name(variant)
+    assert name == result


### PR DESCRIPTION
Populate the source and statementId fields in the kb_matches table for upload to IPR

New features
- Fills in externalStatementId and externalSource fields of kbMatches section
- Makes generating analyst comments optional (since these are not included in all templates)
- Use fallback to hgvs (protein then cds then genomic) when variant field is empty

Improvements
- Adds more unit tests
- Use python 3.6-3.10 for quick tests
- Use even numbered pythons for long tests