### PR TITLE
Reduce live API conn in tests

### DIFF
--- a/ipr/annotate.py
+++ b/ipr/annotate.py
@@ -71,7 +71,6 @@ def get_gene_information(
     variants = graphkb_conn.query(
         {'target': 'Variant', 'returnProperties': ['@class', 'reference1', 'reference2']},
     )
-    print(variants)
 
     gene_flags: Dict[str, Set[str]] = {
         'cancerRelated': set(),

--- a/ipr/annotate.py
+++ b/ipr/annotate.py
@@ -4,23 +4,17 @@ handles annotating variants with annotation information from graphkb
 from requests.exceptions import HTTPError
 
 from graphkb import GraphKBConnection
+from graphkb import genes as gkb_genes
+from graphkb import match as gkb_match
+from graphkb import vocab as gkb_vocab
 from graphkb.constants import (
     BASE_RETURN_PROPERTIES,
     BASE_THERAPEUTIC_TERMS,
     GENERIC_RETURN_PROPERTIES,
 )
-from graphkb.genes import get_oncokb_oncogenes, get_oncokb_tumour_supressors
-from graphkb.match import (
-    INPUT_COPY_CATEGORIES,
-    get_equivalent_features,
-    match_category_variant,
-    match_copy_variant,
-    match_expression_variant,
-    match_positional_variant,
-)
+from graphkb.match import INPUT_COPY_CATEGORIES
 from graphkb.types import Record, Statement, Variant
 from graphkb.util import FeatureNotFoundError, convert_to_rid_list
-from graphkb.vocab import get_terms_set
 from progressbar import progressbar
 from typing import Dict, Iterable, List, Set
 
@@ -31,7 +25,7 @@ from .util import convert_to_rid_set, logger
 
 
 def get_therapeutic_associated_genes(graphkb_conn: GraphKBConnection) -> Set[str]:
-    therapeutic_relevance = get_terms_set(graphkb_conn, BASE_THERAPEUTIC_TERMS)
+    therapeutic_relevance = gkb_vocab.get_terms_set(graphkb_conn, BASE_THERAPEUTIC_TERMS)
     statements = graphkb_conn.query(
         {
             'target': 'Statement',
@@ -77,6 +71,7 @@ def get_gene_information(
     variants = graphkb_conn.query(
         {'target': 'Variant', 'returnProperties': ['@class', 'reference1', 'reference2']},
     )
+    print(variants)
 
     gene_flags: Dict[str, Set[str]] = {
         'cancerRelated': set(),
@@ -94,16 +89,18 @@ def get_gene_information(
             gene_flags['knownSmallMutation'].add(variant['reference1'])
 
     logger.info('fetching oncogenes list')
-    gene_flags['oncogene'] = convert_to_rid_set(get_oncokb_oncogenes(graphkb_conn))
+    gene_flags['oncogene'] = convert_to_rid_set(gkb_genes.get_oncokb_oncogenes(graphkb_conn))
     logger.info('fetching tumour supressors list')
-    gene_flags['tumourSuppressor'] = convert_to_rid_set(get_oncokb_tumour_supressors(graphkb_conn))
+    gene_flags['tumourSuppressor'] = convert_to_rid_set(
+        gkb_genes.get_oncokb_tumour_supressors(graphkb_conn)
+    )
     logger.info('fetching therapeutic associated genes lists')
     gene_flags['therapeuticAssociated'] = get_therapeutic_associated_genes(graphkb_conn)
 
     result = []
 
     for gene_name in gene_names:
-        equivalent = convert_to_rid_set(get_equivalent_features(graphkb_conn, gene_name))
+        equivalent = convert_to_rid_set(gkb_match.get_equivalent_features(graphkb_conn, gene_name))
 
         row = IprGene({'name': gene_name})
 
@@ -173,7 +170,7 @@ def get_second_pass_variants(
     }
 
     for (reference1, variant_type) in inferred_variants:
-        variants = match_category_variant(graphkb_conn, reference1, variant_type)
+        variants = gkb_match.match_category_variant(graphkb_conn, reference1, variant_type)
 
         for variant in variants:
             all_inferred_matches[variant['@rid']] = variant
@@ -261,9 +258,9 @@ def annotate_category_variants(
 
         try:
             if copy_variant:
-                matches = match_copy_variant(graphkb_conn, gene, variant)
+                matches = gkb_match.match_copy_variant(graphkb_conn, gene, variant)
             else:
-                matches = match_expression_variant(graphkb_conn, gene, variant)
+                matches = gkb_match.match_expression_variant(graphkb_conn, gene, variant)
 
             for ipr_row in get_ipr_statements_from_variants(graphkb_conn, matches, disease_name):
                 new_row = KbMatch({'variant': row['key'], 'variantType': row['variantType']})
@@ -318,7 +315,7 @@ def annotate_positional_variants(
             continue
 
         try:
-            matches = match_positional_variant(graphkb_conn, variant)
+            matches = gkb_match.match_positional_variant(graphkb_conn, variant)
 
             for ipr_row in get_ipr_statements_from_variants(graphkb_conn, matches, disease_name):
                 new_row = KbMatch({'variant': row['key'], 'variantType': row['variantType']})

--- a/ipr/ipr.py
+++ b/ipr/ipr.py
@@ -3,9 +3,9 @@ Contains functions specific to formatting reports for IPR that are unlikely to b
 by other reporting systems
 """
 from graphkb import GraphKBConnection
-from graphkb.statement import categorize_relevance
+from graphkb import statement as gkb_statement
+from graphkb import vocab as gkb_vocab
 from graphkb.types import Ontology, Statement
-from graphkb.vocab import get_term_tree
 from typing import Dict, Iterable, List, Set, Tuple
 
 from .constants import APPROVED_EVIDENCE_LEVELS, VARIANT_CLASSES
@@ -90,7 +90,8 @@ def convert_statements_to_alterations(
         - only report disease matched prognostic markers https://www.bcgsc.ca/jira/browse/GERO-72 and GERO-196
     """
     disease_matches = {
-        r['@rid'] for r in get_term_tree(graphkb_conn, disease_name, ontology_class='Disease')
+        r['@rid']
+        for r in gkb_vocab.get_term_tree(graphkb_conn, disease_name, ontology_class='Disease')
     }
 
     if not disease_matches:
@@ -111,7 +112,7 @@ def convert_statements_to_alterations(
 
         disease_match = len(diseases) == 1 and diseases[0]['@rid'] in disease_matches
 
-        ipr_section = categorize_relevance(graphkb_conn, relevance_id)
+        ipr_section = gkb_statement.categorize_relevance(graphkb_conn, relevance_id)
 
         if ipr_section == 'therapeutic':
             for level in statement['evidenceLevel'] or []:

--- a/tests/test_ipr.py
+++ b/tests/test_ipr.py
@@ -54,7 +54,6 @@ def base_graphkb_statement(disease_id: str = 'disease', relevance_rid: str = 'ot
 @pytest.fixture(autouse=True)
 def mock_get_term_tree(monkeypatch):
     def mock_func(*pos, **kwargs):
-        print('called mock_func')
         return [{'@rid': d} for d in DISEASE_RIDS]
 
     monkeypatch.setattr(gkb_vocab, 'get_term_tree', mock_func)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,9 @@
+class QueryMock:
+    def __init__(self, return_values) -> None:
+        self.return_values = return_values
+        self.index = -1
+
+    def __call__(self, *args, **kwargs):
+        self.index += 1
+        ret_val = self.return_values[self.index] if self.index < len(self.return_values) else []
+        return ret_val


### PR DESCRIPTION
- Mock graphkb functions instead of lower level API query function to make tests less fragile to graphkb updates