### PR TITLE
Release/v3.11.0 devsu 2034 variant display names

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ known_standard_library = requests
 
 [metadata]
 name = ipr
-version = 3.10.0
+version = 3.11.0
 author_email = ipr@bcgsc.ca
 author = ipr
 maintainer_email = ipr@bcgsc.ca


### PR DESCRIPTION
Release v3.11.0
New Feature:
 * DEVSU-2034 - add a 'displayName' property to all variants as the preferred display string repr.