### PR TITLE
SDEV-4029 - setup.cfg - remove biopython version restriction

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ dependency_links = []
 include_package_data = True
 install_requires =
     graphkb>=1.11.0
-    biopython==1.76
+    biopython
     progressbar2>=3.51.0, <4
     pandas>=1.1.0
     jsonschema


### PR DESCRIPTION
biopython==1.76 did not install on python 3.11