### PR TITLE
Release/v3.11.1 sdev 4029 variant type check err message not crash

### DIFF
--- a/ipr/annotate.py
+++ b/ipr/annotate.py
@@ -281,8 +281,10 @@ def annotate_positional_variants(
 
     # drop duplicates
     alterations: List[KbMatch] = list(set(alterations))
+
+    variant_types = ", ".join(sorted(set([alt['variantType'] for alt in alterations])))
     logger.info(
-        f'matched {len(variants)} positional variants to {len(alterations)} graphkb annotations'
+        f'matched {len(variants)} {variant_types} positional variants to {len(alterations)} graphkb annotations'
     )
 
     return alterations

--- a/ipr/main.py
+++ b/ipr/main.py
@@ -111,16 +111,30 @@ def clean_unsupported_content(upload_content: Dict) -> Dict:
     to implement but is not yet supported by the upload
     """
     drop_columns = ['variant', 'variantType', 'histogramImage']
-    for variant_section in [
+    # DEVSU-2034 - use a 'displayName'
+    VARIANT_LIST_KEYS = [
         'expressionVariants',
         'smallMutations',
         'copyVariants',
         'structuralVariants',
-    ]:
-        for variant in upload_content[variant_section]:
+        'probeResults',
+        'msi',
+    ]
+    for variant_list_section in VARIANT_LIST_KEYS:
+        for variant in upload_content.get(variant_list_section, []):
+            if not variant.get('displayName'):
+                variant['displayName'] = (
+                    variant.get('variant') or variant.get('kbCategory') or variant.get('key', '')
+                )
             for col in drop_columns:
                 if col in variant:
                     del variant[col]
+    # tmburMutationBurden is a single value, not list
+    if upload_content.get('tmburMutationBurden'):
+        if not upload_content['tmburMutationBurden'].get('displayName'):
+            upload_content['tmburMutationBurden']['displayName'] = upload_content[
+                'tmburMutationBurden'
+            ].get('kbCategory', '')
 
     for row in upload_content['kbMatches']:
         del row['kbContextId']

--- a/ipr/main.py
+++ b/ipr/main.py
@@ -1,6 +1,7 @@
 import argparse
 import datetime
 import json
+import jsonschema.exceptions
 import logging
 import os
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
@@ -146,7 +147,12 @@ def clean_unsupported_content(upload_content: Dict) -> Dict:
     return upload_content
 
 
-def create_report(
+def create_report(**kwargs) -> Dict:
+    logger.warning("Deprecated function 'create_report' called - use ipr_report instead")
+    return ipr_report(**kwargs)
+
+
+def ipr_report(
     username: str,
     password: str,
     content: Dict,
@@ -190,7 +196,12 @@ def create_report(
         datefmt='%m-%d-%y %H:%M:%S',
     )
     # validate the JSON content follows the specification
-    validate_report_content(content)
+    try:
+        validate_report_content(content)
+    except jsonschema.exceptions.ValidationError as err:
+        logger.error("Failed schema check - report variants may be corrupted or unmatched.")
+        logger.error(f"Failed schema check: {err}")
+
     kb_disease_match = content['kbDiseaseMatch']
 
     # validate the input variants

--- a/ipr/main.py
+++ b/ipr/main.py
@@ -126,6 +126,10 @@ def clean_unsupported_content(upload_content: Dict) -> Dict:
                 variant['displayName'] = (
                     variant.get('variant') or variant.get('kbCategory') or variant.get('key', '')
                 )
+            if variant_list_section == 'probeResults':
+                # currently probeResults will error if they do NOT have a 'variant' column.
+                # smallMutations will error if they DO have a 'variant' column.
+                continue
             for col in drop_columns:
                 if col in variant:
                     del variant[col]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ known_standard_library = requests
 
 [metadata]
 name = ipr
-version = 3.9.0
+version = 3.10.0
 author_email = ipr@bcgsc.ca
 author = ipr
 maintainer_email = ipr@bcgsc.ca

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ known_standard_library = requests
 
 [metadata]
 name = ipr
-version = 3.11.0
+version = 3.11.1
 author_email = ipr@bcgsc.ca
 author = ipr
 maintainer_email = ipr@bcgsc.ca

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ known_standard_library = requests
 
 [metadata]
 name = ipr
-version = 3.10.0
+version = 3.11.0
 author_email = ipr@bcgsc.ca
 author = ipr
 maintainer_email = ipr@bcgsc.ca


### PR DESCRIPTION
Release v3.11.1
Improvements:
 * SDEV-4029 - make the schema checks into error messages instead of ValueErrors.