### PR TITLE
Bugfix/workflow updates

### DIFF
--- a/.github/workflows/publishdevdocs.yml
+++ b/.github/workflows/publishdevdocs.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: [3.8]
     steps:
     - name: checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: install and build

--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
From the last deployment, upload to pypi failed:
[deploy](https://github.com/bcgsc/pori_ipr_python/actions/runs/8160791335/job/22308161731)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-python@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

I think these changes are correct, but I do not know how to test without merging to master.